### PR TITLE
add arc42 architecture documentation template

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -58,6 +58,7 @@ contain some resources that are also present in more niche lists.
 
 ## Documentation
 
+- [arc42](https://arc42.org/) - Template for documentation and communication of software and system architectures.
 - [Architectural Decision Records](https://adr.github.io/) - Version and document architectural decisions the same way you do with code.
 - [Documenting architecture](https://dzone.com/articles/documenting-architecture-1) - Pragmatic tips on how to effectively document software architecture.
 


### PR DESCRIPTION
arc42 is a way to structure and document many information that was produced during architectural work. I find it very useful to have a place to put things in and a reminder of what else I could think about.