### PR TITLE
Add karasu to Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -94,6 +94,7 @@ contain some resources that are also present in more niche lists.
 - [Sketchboard.io](https://sketchboard.io/) - Collaborative sketchboarding.
 - [ERD Lab](https://www.erdlab.io/) - Free cloud based entity relationship diagram (ERD) tool made for developers.
 - [Pumler](https://pumler.com) - Real-time collaborative text-to-diagram editor for PlantUML, Mermaid, and Structurizr (C4), with browser-based PNG/SVG export.
+- [karasu](https://github.com/kompiro/karasu) - Open-source text-based DSL for modeling the logical, physical, and organizational structure of a system in one language; C4-inspired, with drill-down navigation and SVG export.
 
 ## Frameworks
 


### PR DESCRIPTION
Adds [karasu](https://github.com/kompiro/karasu) to the **Tools** section.

karasu is an open-source, text-based DSL for modeling a system's logical, physical, and organizational structure in one language. It is C4-inspired but takes a distinct position through continuous drill-down navigation and a first-class organizational axis, and renders to SVG.

- Format follows the existing `- [Name](link) - Description` convention and is appended to the bottom of the Tools category.
- First-hand experience: I am the author/maintainer of the project.

Repository: https://github.com/kompiro/karasu